### PR TITLE
New parameter `withMathJax` that allows for math formulas displayed

### DIFF
--- a/R/observe_helpers.R
+++ b/R/observe_helpers.R
@@ -5,6 +5,8 @@
 #' @export
 #' @param session The session object in your shiny app.
 #' @param help_dir A character string of the directory containing your helpfiles.
+#' @param withMathJax If \code{TRUE} the MathJax library is added to allow for 
+#'   math expressions in markdown content.
 #' 
 #' @examples
 #' server <- function(input, output, session){
@@ -18,7 +20,8 @@
 #' }
 #' 
 observe_helpers <- function(session = shiny::getDefaultReactiveDomain(),
-                            help_dir = "helpfiles") {
+                            help_dir = "helpfiles",
+                            withMathJax = FALSE) {
   
   shiny::observeEvent(
     
@@ -40,6 +43,9 @@ observe_helpers <- function(session = shiny::getDefaultReactiveDomain(),
         
         if (file.exists(file)) {
           content <- shiny::includeMarkdown(file)
+          if (withMathJax) {
+            content <- withMathJax(content)
+          }
         } else {
           title <- shiny::tags$strong("Helpfile Not Found")
           content <- "Sorry, there doesn't seem to be a helpfile for this yet!"

--- a/R/observe_helpers.R
+++ b/R/observe_helpers.R
@@ -44,7 +44,7 @@ observe_helpers <- function(session = shiny::getDefaultReactiveDomain(),
         if (file.exists(file)) {
           content <- shiny::includeMarkdown(file)
           if (withMathJax) {
-            content <- withMathJax(content)
+            content <- shiny::withMathJax(content)
           }
         } else {
           title <- shiny::tags$strong("Helpfile Not Found")

--- a/man/observe_helpers.Rd
+++ b/man/observe_helpers.Rd
@@ -5,12 +5,15 @@
 \title{Observe Helper Action Buttons}
 \usage{
 observe_helpers(session = shiny::getDefaultReactiveDomain(),
-  help_dir = "helpfiles")
+  help_dir = "helpfiles", withMathJax = FALSE)
 }
 \arguments{
 \item{session}{The session object in your shiny app.}
 
 \item{help_dir}{A character string of the directory containing your helpfiles.}
+
+\item{withMathJax}{If \code{TRUE} the MathJax library is added to allow for 
+math expressions in markdown content.}
 }
 \description{
 Function to show a modal dialog, observing each of the help icons in the app.


### PR DESCRIPTION
Hi,

I would really like to have the possibility to add mathematical formulas to the help dialogs. 
Therefore I added an option `withMathJax` to `observe_helpers`, whether the MathJax library should be added to allow for math expressions in markdown content.

Alternatively one could think about adding this parameter to the `helper` function.

Thanks and best regards, Kornel