### PR TITLE
Putting helper icons behind the dropdown menu by setting z-index to 900

### DIFF
--- a/inst/assets/shinyhelper.css
+++ b/inst/assets/shinyhelper.css
@@ -9,7 +9,7 @@
   position: absolute;
   top: 0;
   right: 10px;
-  z-index: 1000;
+  z-index: 900;
   width: 0;
   height: 10px;
   padding: 0; 


### PR DESCRIPTION
This puts the z-index of the shinyhelper-container to 900 and puts the helper icons behind the dropdown menu, since dropdown-menu has a z-index of 1000 and dropdown-backdrop one of 990. Fixes issue #6.