### PR TITLE
change name of question icon to fix bug in helper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,5 +8,5 @@ Description: Creates a lightweight way to add markdown helpfiles to 'shiny' apps
     using modal dialog boxes, with no need to observe each help button separately.
 License: GPL-3
 Imports: shiny, markdown
-RoxygenNote: 6.1.1
+RoxygenNote: 7.2.1
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ### shinyhelper 0.3.2.9000
 
+* Change name of font awesome question mark icon to circle-question
+inline with new icon name change
 
 # shinyhelper 0.3.2
 

--- a/R/helper.R
+++ b/R/helper.R
@@ -31,7 +31,7 @@
 #'        content = "ClickHelp")  # looks for 'helpfiles/ClickHelp.md'
 #'        
 helper <- function(shiny_tag, 
-                   icon = "question-circle",
+                   icon = "circle-question",
                    colour = NULL,
                    type = "markdown",
                    title = "",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can change the type of icon used and its colour, as well as passing CSS inli
 
 ### Icon
 
-The icons are `shiny::icon("question-circle")` icons by default, but you can change them individually using the `icon` argument of `helper()`:
+The icons are `shiny::icon("circle-question")` icons by default, but you can change them individually using the `icon` argument of `helper()`:
 
 ```
 plotOutput(outputId = "plot") %>% helper(icon = "exclamation")

--- a/man/helper.Rd
+++ b/man/helper.Rd
@@ -4,9 +4,19 @@
 \alias{helper}
 \title{Augment a shiny.tag with a question mark helper button}
 \usage{
-helper(shiny_tag, icon = "question-circle", colour = NULL,
-  type = "markdown", title = "", content = "", size = "m",
-  buttonLabel = "Okay", easyClose = TRUE, fade = FALSE, ...)
+helper(
+  shiny_tag,
+  icon = "circle-question",
+  colour = NULL,
+  type = "markdown",
+  title = "",
+  content = "",
+  size = "m",
+  buttonLabel = "Okay",
+  easyClose = TRUE,
+  fade = FALSE,
+  ...
+)
 }
 \arguments{
 \item{shiny_tag}{A shiny element, such as an input or output (but any shiny tag will do).}

--- a/man/observe_helpers.Rd
+++ b/man/observe_helpers.Rd
@@ -4,8 +4,11 @@
 \alias{observe_helpers}
 \title{Observe Helper Action Buttons}
 \usage{
-observe_helpers(session = shiny::getDefaultReactiveDomain(),
-  help_dir = "helpfiles", withMathJax = FALSE)
+observe_helpers(
+  session = shiny::getDefaultReactiveDomain(),
+  help_dir = "helpfiles",
+  withMathJax = FALSE
+)
 }
 \arguments{
 \item{session}{The session object in your shiny app.}

--- a/man/shinyhelper.Rd
+++ b/man/shinyhelper.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{shinyhelper}
 \alias{shinyhelper}
-\alias{shinyhelper-package}
 \title{shinyhelper.}
 \description{
 Easily add markdown helpfiles to your shiny apps, by adding a single function


### PR DESCRIPTION
Hello, I have been using `shinyhelper` for my apps and have noticed that the icon for question mark has changed name from from `question-circle` to `circle-question`. 

I was previously getting this warning when running my app

```
This Font Awesome icon ('question-circle') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE
```

This is fixed in this PR. 

I have not bumped the package version in DESCRIPTION or NEWS as I was unsure of your versioning system but did update the documentation with `roxygen2`.

```
> sessionInfo()
R version 4.2.0 (2022-04-22)
Platform: x86_64-apple-darwin17.0 (64-bit)
Running under: macOS Monterey 12.4

Matrix products: default
LAPACK: /Library/Frameworks/R.framework/Versions/4.2/Resources/lib/libRlapack.dylib

locale:
[1] en_GB.UTF-8/en_GB.UTF-8/en_GB.UTF-8/C/en_GB.UTF-8/en_GB.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
 [1] shinydashboardPlus_2.0.3 shinydashboard_0.7.2     FNN_1.1.3.1             
 [4] shinyjs_2.1.0            shinyWidgets_0.7.3       dendextend_1.16.0       
 [7] tidyr_1.2.1              patchwork_1.1.2          ggplot2_3.3.6           
[10] colorspace_2.0-3         colourpicker_1.1.1       shinythemes_1.2.0       
[13] DT_0.25                  shiny_1.7.2              dplyr_1.0.10            
[16] shinyhelper_0.3.2   
```